### PR TITLE
Null safety

### DIFF
--- a/glados/lib/src/any.dart
+++ b/glados/lib/src/any.dart
@@ -107,11 +107,11 @@ extension AnyUtils on Any {
 extension CombinableAny on Any {
   /// Combines n values. Is not typesafe, so it's private.
   Generator<T> _combineN<T>(
-    List<Generator<dynamic>> generators,
-    T Function(List<dynamic> values) combiner,
+    List<Generator<Object>> generators,
+    T Function(List<Object> values) combiner,
   ) {
     return (random, size) {
-      return ShrinkableCombination(<Shrinkable<T>>[
+      return ShrinkableCombination(<Shrinkable<Object>>[
         for (final generator in generators) generator(random, size),
       ], combiner);
     };
@@ -340,11 +340,11 @@ extension CombinableAny on Any {
 class ShrinkableCombination<T> implements Shrinkable<T> {
   ShrinkableCombination(this.fields, this.combiner);
 
-  final List<Shrinkable<T>> fields;
-  final T Function(List<dynamic> values) combiner;
+  final List<Shrinkable<Object>> fields;
+  final T Function(List<Object> values) combiner;
 
   @override
-  T get value => combiner(fields);
+  T get value => combiner(fields.map((shrinkable) => shrinkable.value).toList());
 
   @override
   Iterable<Shrinkable<T>> shrink() sync* {

--- a/glados/lib/src/anys.dart
+++ b/glados/lib/src/anys.dart
@@ -111,12 +111,13 @@ extension ListAnys on Any {
   /// inclusive, [max] is exclusive.
   Generator<core.List<T>> listWithLengthInRange<T>(
       core.int? min, core.int? max, Generator<T> itemGenerator) {
-    assert(min == null || min >= 0);
+    final actualMin = min ?? 0;
+    assert(actualMin >= 0);
     return (random, size) {
-      final length = random.nextIntInRange(min ?? 0, max ?? size);
+      final length = random.nextIntInRange(actualMin, math.max(max ?? size, actualMin + 1));
       return ShrinkableList(<Shrinkable<T>>[
         for (var i = 0; i < length; i++) itemGenerator(random, size),
-      ], min);
+      ], actualMin);
     };
   }
 
@@ -156,13 +157,14 @@ class ShrinkableList<T> implements Shrinkable<core.List<T>> {
 
 extension SetAyns on Any {
   Generator<core.Set<T>> setWithLengthInRange<T>(
-      core.int min, core.int? max, Generator<T> itemGenerator) {
-    assert(min >= 0);
+      core.int? min, core.int? max, Generator<T> itemGenerator) {
+    final actualMin = min ?? 0;
+    assert(actualMin >= 0);
     return (random, size) {
-      final length = random.nextIntInRange(min, math.max(max ?? size, min + 1));
+      final length = random.nextIntInRange(actualMin, math.max(max ?? size, actualMin + 1));
       return ShrinkableSet(<Shrinkable<T>>{
         for (var i = 0; i < length; i++) itemGenerator(random, size),
-      }, min);
+      }, actualMin);
     };
   }
 
@@ -176,7 +178,7 @@ extension SetAyns on Any {
 }
 
 class ShrinkableSet<T> implements Shrinkable<core.Set<T>> {
-  ShrinkableSet(this.items, this.minLength);
+  ShrinkableSet(this.items, core.int? minLength) : minLength = minLength ?? 0;
 
   final core.Set<Shrinkable<T>> items;
   final core.int minLength;

--- a/glados/lib/src/glados.dart
+++ b/glados/lib/src/glados.dart
@@ -14,7 +14,7 @@ class ExploreConfig {
     this.numRuns = 100,
     this.initialSize = 10,
     this.speed = 1,
-    Random random,
+    Random? random,
   })  : assert(numRuns != null),
         assert(numRuns > 0),
         assert(initialSize != null),
@@ -107,7 +107,7 @@ class ExploreConfig {
 /// To customize the exploration phase, provide an [ExploreConfig] configuration.
 /// See the [ExploreConfig] doc comments for more information.
 class Glados<T> {
-  Glados([Generator<T> generator, ExploreConfig explore])
+  Glados([Generator<T>? generator, ExploreConfig? explore])
       : generator = generator ?? Any.defaultForWithBeautifulError<T>(1, 0),
         explore = explore ?? ExploreConfig();
 
@@ -119,19 +119,19 @@ class Glados<T> {
   void test(
     String description,
     Tester<T> body, {
-    String testOn,
-    test_package.Timeout timeout,
+    String? testOn,
+    test_package.Timeout? timeout,
     dynamic skip,
     dynamic tags,
-    Map<String, dynamic> onPlatform,
-    int retry,
+    Map<String, dynamic>? onPlatform,
+    int? retry,
   }) {
     final stats = Statistics();
 
     /// Explores the input space for inputs that break the property. This works
     /// by gradually increasing the size. Returns the first value where the
     /// property is broken or null if no value was found.
-    Future<Shrinkable<T>> explorePhase() async {
+    Future<Shrinkable<T>?> explorePhase() async {
       var count = 0;
       var size = explore.initialSize;
 
@@ -195,12 +195,12 @@ class Glados<T> {
   void testWithRandom(
     String description,
     TesterWithRandom<T> body, {
-    String testOn,
-    test_package.Timeout timeout,
+    String? testOn,
+    test_package.Timeout? timeout,
     dynamic skip,
     dynamic tags,
-    Map<String, dynamic> onPlatform,
-    int retry,
+    Map<String, dynamic>? onPlatform,
+    int? retry,
   }) {
     // How many random values the test needs shouldn't change what other inputs
     // are chosen. Otherwise, if a test fails, you edit the content and then the
@@ -227,9 +227,9 @@ class Glados<T> {
 /// See [Glados] for more information about the arguments.
 class Glados2<First, Second> {
   Glados2([
-    Generator<First> firstGenerator,
-    Generator<Second> secondGenerator,
-    ExploreConfig explore,
+    Generator<First>? firstGenerator,
+    Generator<Second>? secondGenerator,
+    ExploreConfig? explore,
   ])  : firstGenerator =
             firstGenerator ?? Any.defaultForWithBeautifulError<First>(2, 0),
         secondGenerator =
@@ -244,15 +244,15 @@ class Glados2<First, Second> {
   void test(
     String description,
     Tester2<First, Second> body, {
-    String testOn,
-    test_package.Timeout timeout,
+    String? testOn,
+    test_package.Timeout? timeout,
     dynamic skip,
     dynamic tags,
-    Map<String, dynamic> onPlatform,
-    int retry,
+    Map<String, dynamic>? onPlatform,
+    int? retry,
   }) {
     Glados(
-      any.combine2(firstGenerator, secondGenerator, (a, b) => [a, b]),
+      any.combine2(firstGenerator, secondGenerator, (First a, Second b) => [a, b]),
     ).test(
       description,
       (input) => body(input[0] as First, input[1] as Second),
@@ -269,12 +269,12 @@ class Glados2<First, Second> {
   void testWithRandom(
     String description,
     Tester2WithRandom<First, Second> body, {
-    String testOn,
-    test_package.Timeout timeout,
+    String? testOn,
+    test_package.Timeout? timeout,
     dynamic skip,
     dynamic tags,
-    Map<String, dynamic> onPlatform,
-    int retry,
+    Map<String, dynamic>? onPlatform,
+    int? retry,
   }) {
     final random = explore.random.nextRandom();
     test(
@@ -294,10 +294,10 @@ class Glados2<First, Second> {
 /// See [Glados] for more information about the arguments.
 class Glados3<First, Second, Third> {
   Glados3([
-    Generator<First> firstGenerator,
-    Generator<Second> secondGenerator,
-    Generator<Third> thirdGenerator,
-    ExploreConfig explore,
+    Generator<First>? firstGenerator,
+    Generator<Second>? secondGenerator,
+    Generator<Third>? thirdGenerator,
+    ExploreConfig? explore,
   ])  : firstGenerator =
             firstGenerator ?? Any.defaultForWithBeautifulError<First>(3, 0),
         secondGenerator =
@@ -315,18 +315,18 @@ class Glados3<First, Second, Third> {
   void test(
     String description,
     Tester3<First, Second, Third> body, {
-    String testOn,
-    test_package.Timeout timeout,
+    String? testOn,
+    test_package.Timeout? timeout,
     dynamic skip,
     dynamic tags,
-    Map<String, dynamic> onPlatform,
-    int retry,
+    Map<String, dynamic>? onPlatform,
+    int? retry,
   }) {
     Glados(any.combine3(
       firstGenerator,
       secondGenerator,
       thirdGenerator,
-      (a, b, c) => [a, b, c],
+      (First a, Second b, Third c) => [a, b, c],
     )).test(
       description,
       (input) => body(input[0] as First, input[1] as Second, input[2] as Third),
@@ -343,12 +343,12 @@ class Glados3<First, Second, Third> {
   void testWithRandom(
     String description,
     Tester3WithRandom<First, Second, Third> body, {
-    String testOn,
-    test_package.Timeout timeout,
+    String? testOn,
+    test_package.Timeout? timeout,
     dynamic skip,
     dynamic tags,
-    Map<String, dynamic> onPlatform,
-    int retry,
+    Map<String, dynamic>? onPlatform,
+    int? retry,
   }) {
     final random = explore.random.nextRandom();
     test(

--- a/glados/lib/src/packages.dart
+++ b/glados/lib/src/packages.dart
@@ -1,5 +1,5 @@
 class Package {
-  Package(this.name, [String gladosName])
+  Package(this.name, [String? gladosName])
       : gladosName = gladosName ?? '${name}_glados';
 
   final name;

--- a/glados/lib/src/rich_type.dart
+++ b/glados/lib/src/rich_type.dart
@@ -7,11 +7,14 @@ class RichType {
   factory RichType.fromString(String string) {
     final parser = _TypeParser(string.replaceAll(' ', ''));
     final type = parser.parse();
-    return parser.cursor == parser.string.length ? type : null;
+    if (parser.cursor != parser.string.length) {
+      throw FormatException(
+          "Extra data after type name in '$string' at ${parser.cursor}");
+    }
+    return type;
   }
   RichType(this.name, [this.children = const []])
-      : assert(name != null),
-        assert(name.isNotEmpty);
+      : assert(name.isNotEmpty);
 
   final String name;
   final List<RichType> children;
@@ -72,7 +75,7 @@ class _TypeParser {
       name.write(current);
       advance();
     }
-    if (name.isEmpty) return null;
+    if (name.isEmpty) throw FormatException("Type '$string' has no name");
     if (current == '>' || current == ',') {
       return RichType(name.toString());
     }
@@ -81,7 +84,9 @@ class _TypeParser {
         advance();
         types.add(parse());
       }
-      if (current != '>') return null;
+      if (current != '>') {
+        throw FormatException("'>' expected in '$string' at position $current");
+      }
       advance();
     }
     return RichType(name.toString(), types);

--- a/glados/lib/src/rich_type.dart
+++ b/glados/lib/src/rich_type.dart
@@ -30,9 +30,9 @@ class RichType {
           children[i] == other.children[i],
       ].every((it) => it);
   @override
-  int get hashCode =>
-      name.hashCode +
-      children.map((child) => child.hashCode).fold(0, (a, b) => a + b);
+  int get hashCode => children
+      .map((child) => child.hashCode)
+      .fold(name.hashCode, (a, b) => a ^ b);
 
   @override
   String toString() {

--- a/glados/lib/src/utils.dart
+++ b/glados/lib/src/utils.dart
@@ -23,7 +23,7 @@ class Statistics {
 }
 
 extension RandomUtils on Random {
-  T choose<T>(List<T> list) => list[nextInt(nextInt(list.length))];
+  T choose<T>(List<T> list) => list[nextInt(list.length)];
   int nextIntInRange(int min, int max) {
     assert(min < max);
     return nextInt(max - min) + min;

--- a/glados/pubspec.yaml
+++ b/glados/pubspec.yaml
@@ -5,7 +5,7 @@ version: 0.4.0
 repository: https://github.com/marcelgarus/glados
 
 environment:
-  sdk: ">=2.6.0 <3.0.0"
+  sdk: ">=2.12.0 <3.0.0"
 
 dependencies:
   analyzer: ^1.1.0

--- a/glados/pubspec.yaml
+++ b/glados/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
   sdk: ">=2.6.0 <3.0.0"
 
 dependencies:
-  analyzer: ">=0.38.0 <0.41.0"
-  build: ">=1.3.0 <1.6.0"
+  analyzer: ^1.1.0
+  build: ^1.6.3
   characters: ^1.0.0
   meta: ^1.0.0
   source_gen: ^0.9.7

--- a/glados/test/anys_test.dart
+++ b/glados/test/anys_test.dart
@@ -47,5 +47,26 @@ void main() {
         expect(number, lessThan(2 << 64));
       });
     });
+    group('ListAnys', () {
+      Glados(any.listWithLengthInRange(null, null, any.always(42)))
+          .test('listWithLengthInRange(null, null, ...)', (list) {
+        expect(list, everyElement(equals(42)));
+      });
+      Glados(any.listWithLengthInRange(5, 10, any.bigInt))
+          .test('listWithLengthInRange(5, 10, ...)', (list) {
+        expect(list.length, greaterThanOrEqualTo(5));
+        expect(list.length, lessThan(10));
+      });
+    });
+    group('SetAnys', () {
+      Glados(any.setWithLengthInRange(null, null, any.always(42)))
+          .test('setWithLengthInRange(null, null, ...)', (set) {
+        expect(set, equals({42}));
+      });
+      Glados(any.setWithLengthInRange(5, 10, any.bigInt))
+          .test('setWithLengthInRange(5, 10, ...)', (set) {
+        expect(set.length, lessThan(10));
+      });
+    });
   });
 }

--- a/glados/test/rich_type_test.dart
+++ b/glados/test/rich_type_test.dart
@@ -64,8 +64,8 @@ void main() {
     );
   });
   test('invalid', () {
-    expect(RichType.fromString('Bar<'), equals(null));
-    expect(RichType.fromString('Bar<Foo'), equals(null));
-    expect(RichType.fromString('Bar<Foo>>'), equals(null));
+    expect(() => RichType.fromString('Bar<'), throwsFormatException);
+    expect(() => RichType.fromString('Bar<Foo'), throwsFormatException);
+    expect(() => RichType.fromString('Bar<Foo>>'), throwsFormatException);
   });
 }

--- a/glados/test/utils_test.dart
+++ b/glados/test/utils_test.dart
@@ -16,7 +16,7 @@ void main() {
         final max = min + length;
         final value = random.nextIntInRange(min, max);
         expect(value, greaterThanOrEqualTo(min));
-        expect(value, lessThan(min));
+        expect(value, lessThan(max));
       },
     );
   });

--- a/glados/test/utils_test.dart
+++ b/glados/test/utils_test.dart
@@ -21,12 +21,12 @@ void main() {
     );
   });
   group('succeeds', () {
-    test('not throwing', () {
-      expect(succeeds((_) {}, true), equals(true));
+    test('not throwing', () async {
+      expect(await succeeds((_) {}, true), equals(true));
     });
-    test('throwing', () {
+    test('throwing', () async {
       expect(
-        succeeds((_) {
+        await succeeds((_) {
           throw 'blub';
         }, true),
         equals(false),

--- a/glados/test/utils_test.dart
+++ b/glados/test/utils_test.dart
@@ -40,6 +40,6 @@ void main() {
   });
   group('JoinableStrings', () {
     test('joinLines', () => expect(['a', 'b'].joinLines(), 'a\nb'));
-    test('joinParts', () => expect(['a', 'b'].joinLines(), 'a\n\nb'));
+    test('joinParts', () => expect(['a', 'b'].joinParts(), 'a\n\nb'));
   });
 }

--- a/glados/test/utils_test.dart
+++ b/glados/test/utils_test.dart
@@ -4,7 +4,7 @@ import 'package:test/test.dart';
 
 void main() {
   group('RandomUtils', () {
-    Glados<List<int>>().testWithRandom(
+    Glados(any.nonEmptyList(any.int)).testWithRandom(
       'choose returns value from list',
       (list, random) {
         expect(list, contains(random.choose(list)));


### PR DESCRIPTION
This branch implements null safety for glados. It's based  on #1.

I haven't migrated `glados/example` and `tuple_glados`:
1. `glados/example` looks unfinished
2. `tuple_glados` seems to be incompatible with current glados - it wasn't updated from `Arbitrary<T>` to `Generator<T>`