### PR TITLE
Dependency updates (`test`, `pedantic` and `analyzer`)

### DIFF
--- a/glados/analysis_options.yaml
+++ b/glados/analysis_options.yaml
@@ -1,1 +1,1 @@
-include: package:pedantic/analysis_options.yaml
+include: package:lints/recommended.yaml

--- a/glados/example/lib/main.dart
+++ b/glados/example/lib/main.dart
@@ -1,5 +1,4 @@
 import 'package:glados/glados.dart';
-import 'package:test/test.dart';
 
 // part 'main.g.dart';
 

--- a/glados/lib/src/any.dart
+++ b/glados/lib/src/any.dart
@@ -387,6 +387,7 @@ class ShrinkableCombination<T> implements Shrinkable<T> {
 }
 
 final _defaultGenerators = {
+  // ignore: prefer_void_to_null
   _TypeWrapper<Null>(): any.null_,
   _TypeWrapper<bool>(): any.bool,
   _TypeWrapper<int>(): any.int,

--- a/glados/lib/src/anys.dart
+++ b/glados/lib/src/anys.dart
@@ -9,6 +9,7 @@ import 'utils.dart';
 
 extension NullAny on Any {
   /// A generator that only generates [null].
+  // ignore: prefer_void_to_null
   Generator<core.Null> get null_ => always(null);
 }
 

--- a/glados/lib/src/packages.dart
+++ b/glados/lib/src/packages.dart
@@ -2,8 +2,8 @@ class Package {
   Package(this.name, [String? gladosName])
       : gladosName = gladosName ?? '${name}_glados';
 
-  final name;
-  final gladosName;
+  final String name;
+  final String gladosName;
 
   @override
   String toString() => name;

--- a/glados/pubspec.yaml
+++ b/glados/pubspec.yaml
@@ -16,4 +16,4 @@ dependencies:
   test: ^1.16.0
 
 dev_dependencies:
-  pedantic: ^1.9.0
+  lints: ^1.0.1

--- a/glados/pubspec.yaml
+++ b/glados/pubspec.yaml
@@ -8,12 +8,12 @@ environment:
   sdk: '>=2.12.0 <3.0.0'
 
 dependencies:
-  analyzer: ^2.3.0
+  analyzer: ^2.8.0
   build: ^2.0.0
   characters: ^1.1.0
   meta: ^1.3.0
   source_gen: ^1.0.0
-  test: ^1.16.0
+  test: ^1.19.5
 
 dev_dependencies:
   lints: ^1.0.1

--- a/glados/pubspec.yaml
+++ b/glados/pubspec.yaml
@@ -1,6 +1,6 @@
 name: glados
 description: '🍰 A simple testing framework that tries to break your properties.'
-version: 1.1.1
+version: 1.1.2
 
 repository: https://github.com/marcelgarus/glados
 

--- a/glados/test/any_test.dart
+++ b/glados/test/any_test.dart
@@ -1,5 +1,4 @@
 import 'package:glados/glados.dart';
-import 'package:test/test.dart';
 
 void main() {
   group('AnyUtils', () {

--- a/glados/test/anys_test.dart
+++ b/glados/test/anys_test.dart
@@ -1,5 +1,4 @@
 import 'package:glados/glados.dart';
-import 'package:test/test.dart';
 
 void main() {
   group('Anys', () {
@@ -62,12 +61,14 @@ void main() {
       });
     });
     group('SetAnys', () {
+      // ignore: deprecated_member_use_from_same_package
       Glados(any.setWithLengthInRange(null, null, any.always(42)))
           .test('setWithLengthInRange(null, null, ...)', (set) {
         if (set.isNotEmpty) {
           expect(set, equals({42}));
         }
       });
+      // ignore: deprecated_member_use_from_same_package
       Glados(any.setWithLengthInRange(5, 10, any.bigInt))
           .test('setWithLengthInRange(5, 10, ...)', (set) {
         expect(set.length, lessThan(10));

--- a/glados/test/rich_type_test.dart
+++ b/glados/test/rich_type_test.dart
@@ -1,6 +1,5 @@
 import 'package:glados/glados.dart';
 import 'package:glados/src/rich_type.dart';
-import 'package:test/test.dart';
 
 extension AnyRichType on Any {
   Generator<RichType> get richType {

--- a/glados/test/utils_test.dart
+++ b/glados/test/utils_test.dart
@@ -1,6 +1,5 @@
 import 'package:glados/glados.dart';
 import 'package:glados/src/utils.dart';
-import 'package:test/test.dart';
 
 void main() {
   group('RandomUtils', () {
@@ -26,9 +25,7 @@ void main() {
     });
     test('throwing', () async {
       expect(
-        await succeeds((_) {
-          throw 'blub';
-        }, true),
+        await succeeds((_) => throw 'blub', true),
         equals(false),
       );
     });


### PR DESCRIPTION
Not much in this PR really, I was just annoyed at being stuck at `analyzer 2.3.0` because glados depended on it.
 