### PR TITLE
Bump dependencies test and analyzer

### DIFF
--- a/glados/pubspec.yaml
+++ b/glados/pubspec.yaml
@@ -8,12 +8,12 @@ environment:
   sdk: '>=2.12.0 <3.0.0'
 
 dependencies:
-  analyzer: ^2.8.0
+  analyzer: ^3.2.0
   build: ^2.0.0
   characters: ^1.1.0
   meta: ^1.3.0
   source_gen: ^1.0.0
-  test: ^1.19.5
+  test: ^1.20.0
 
 dev_dependencies:
   lints: ^1.0.1


### PR DESCRIPTION
Adding glados to the project while using flutter 2.8 will produce the error:
```
Because test >=1.20.0 depends on test_api 0.4.9 and test >=1.19.4 <1.20.0 depends on test_api 0.4.8, test >=1.19.4 requires test_api 0.4.8 or 0.4.9.
And because glados >=1.1.2 depends on test ^1.19.5 and every version of flutter_test from sdk depends on test_api 0.4.3, glados >=1.1.2 is incompatible with flutter_test from sdk.
So, because project depends on both flutter_test from sdk and glados ^1.1.2, version solving failed.
pub get failed (1; So, because project depends on both flutter_test from sdk and glados ^1.1.2, version solving failed.)
```

This PR bumps the `test`'s version to solve the issue. Bumping `analyzer` is just a plus 😉 