### PR TITLE
Fix any.bigIntInRange

### DIFF
--- a/glados/lib/src/anys.dart
+++ b/glados/lib/src/anys.dart
@@ -145,9 +145,8 @@ extension BigIntAnys on Any {
       generate: (random, size) {
         final actualMin = min ?? core.BigInt.from(-size);
         final actualMax = max ?? core.BigInt.from(size);
-        final bits =
-            (core.BigInt.two * (actualMax - actualMin) + core.BigInt.one)
-                .bitLength;
+        assert(actualMax > actualMin);
+        final bits = (actualMax - actualMin).bitLength;
         var bigInt = core.BigInt.zero;
         for (var i = 0; i < bits; i++) {
           bigInt = bigInt * core.BigInt.two;
@@ -155,7 +154,7 @@ extension BigIntAnys on Any {
             bigInt += core.BigInt.one;
           }
         }
-        return bigInt - actualMin;
+        return bigInt % (actualMax - actualMin) + actualMin;
       },
       shrink: (input) sync* {
         if (input > core.BigInt.zero) {

--- a/glados/test/anys_test.dart
+++ b/glados/test/anys_test.dart
@@ -74,5 +74,22 @@ void main() {
         expect(set.length, lessThan(10));
       });
     });
+    group('BigIntAnys', () {
+      Glados3(any.int, any.bigInt, any.bigInt).testWithRandom(
+        'bigIntInRange',
+        (size, min, max, random) {
+          if (min >= max) {
+            expect(
+              () => any.bigIntInRange(min, max)(random, size),
+              throwsA(anything),
+            );
+            return;
+          }
+          final generated = any.bigIntInRange(min, max)(random, size).value;
+          expect(generated, greaterThanOrEqualTo(min));
+          expect(generated, lessThan(max));
+        },
+      );
+    });
   });
 }


### PR DESCRIPTION
The current implementation doesn't generate values in `[min; max)`. The proposed one does, although it's biased towards `min` because of the `%`.