### PR TITLE
Fix for issue-21

### DIFF
--- a/glados/lib/src/glados.dart
+++ b/glados/lib/src/glados.dart
@@ -254,6 +254,7 @@ class Glados2<First, Second> {
         secondGenerator,
         (First a, Second b) => [a, b],
       ),
+      explore,
     ).test(
       description,
       (input) => body(input[0] as First, input[1] as Second),
@@ -323,12 +324,15 @@ class Glados3<First, Second, Third> {
     Map<String, dynamic>? onPlatform,
     int? retry,
   }) {
-    Glados(any.combine3(
-      firstGenerator,
-      secondGenerator,
-      thirdGenerator,
-      (First a, Second b, Third c) => [a, b, c],
-    )).test(
+    Glados(
+      any.combine3(
+        firstGenerator,
+        secondGenerator,
+        thirdGenerator,
+        (First a, Second b, Third c) => [a, b, c],
+      ),
+      explore,
+    ).test(
       description,
       (input) => body(input[0] as First, input[1] as Second, input[2] as Third),
       testOn: testOn,


### PR DESCRIPTION
Forward `explore` to the Glados constructor to make the property also used in the Glados2 and Glados3 implementation.
[Issue](https://github.com/MarcelGarus/glados/issues/21)

Maybe some tests should get added to verify the fix and prevent similar bugs in the future?