### PR TITLE
Integrate Github Actions

### DIFF
--- a/.github/workflows/analyze-and-test.yml
+++ b/.github/workflows/analyze-and-test.yml
@@ -50,11 +50,9 @@ jobs:
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v3
         with:
-          token: ${{ secrets.CODECOV_TOKEN }}
           files: coverage/lcov.info
 
       - name: Upload coverage reports to Coveralls
         uses: coverallsapp/github-action@v2
         with:
-          github-token: ${{ secrets.COVERALLS_REPO_TOKEN }}
           path-to-lcov: coverage/lcov.info

--- a/.github/workflows/analyze-and-test.yml
+++ b/.github/workflows/analyze-and-test.yml
@@ -46,13 +46,3 @@ jobs:
 
       - name: Run tests with coverage
         run: dart pub global run coverage:test_with_coverage
-
-      - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@v3
-        with:
-          files: coverage/lcov.info
-
-      - name: Upload coverage reports to Coveralls
-        uses: coverallsapp/github-action@v2
-        with:
-          path-to-lcov: coverage/lcov.info

--- a/.github/workflows/analyze-and-test.yml
+++ b/.github/workflows/analyze-and-test.yml
@@ -1,0 +1,60 @@
+name: Analyze and test
+
+defaults:
+  run:
+    working-directory: glados
+
+on:
+  push:
+    branches: [ main, develop ]
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  analyze:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+      - uses: dart-lang/setup-dart@v1
+        with:
+          sdk: stable
+
+      - name: Install dependencies
+        run: dart pub get
+
+      - name: Verify formatting
+        run: dart format --output=none --line-length=80 --set-exit-if-changed .
+
+      - name: Analyze project source
+        run: dart analyze --fatal-infos
+
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+      - uses: dart-lang/setup-dart@v1
+        with:
+          sdk: stable
+
+      - name: Install dependencies
+        run: dart pub get
+
+      - name: Prepare coverage package
+        run: dart pub global activate coverage
+
+      - name: Run tests with coverage
+        run: dart pub global run coverage:test_with_coverage
+
+      - name: Upload coverage reports to Codecov
+        uses: codecov/codecov-action@v3
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: coverage/lcov.info
+
+      - name: Upload coverage reports to Coveralls
+        uses: coverallsapp/github-action@v2
+        with:
+          github-token: ${{ secrets.COVERALLS_REPO_TOKEN }}
+          path-to-lcov: coverage/lcov.info

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Analyze and test](https://github.com/MarcelGarus/glados/actions/workflows/analyze-and-test.yml/badge.svg)](https://github.com/MarcelGarus/glados/actions/workflows/analyze-and-test.yml)
+
 # Welcome to the Glados repository!
 
 This repository contains the `glados` core package, a property-based testing framework for Dart.


### PR DESCRIPTION
Hi, I've just added actions to a dart assertion library I've created (which I also test using Glados, nice work btw ;) ), so I figured I'd give something back by adapting the actions I run on my lib. 

The coverage reports generated should integrate nicely with services like Codecov or coveralls (if that's of any interest). 