### PR TITLE
Remove unneeded dependencies

### DIFF
--- a/glados/pubspec.yaml
+++ b/glados/pubspec.yaml
@@ -8,11 +8,7 @@ environment:
   sdk: '>=2.12.0 <3.0.0'
 
 dependencies:
-  analyzer: ^5.1.0
-  build: ^2.0.0
   characters: ^1.1.0
-  meta: ^1.3.0
-  source_gen: ^1.0.0
   test: ^1.20.0
 
 dev_dependencies:


### PR DESCRIPTION
Glados is currently incompatible with analyzer 6+. I came here to fix that but realized that there are a number of dependencies that are not actually needed.